### PR TITLE
remove persistent miner weights

### DIFF
--- a/src/subnet/validator/validator.py
+++ b/src/subnet/validator/validator.py
@@ -545,7 +545,7 @@ class Validator:
         """
         score_dict = cut_to_max_allowed_weights(score_dict, settings.MAX_ALLOWED_WEIGHTS)
         self.weights_storage.setup()
-        weighted_scores: Dict[int, int] = self.weights_storage.read()
+        weighted_scores: Dict[int, int] = dict()
 
         logger.debug(f"Setting weights for scores", score_dict=score_dict)
         score_sum = sum(score_dict.values())


### PR DESCRIPTION
Old miners that were active before could persist by loading their weights from the weights storage file.

If there's no current or future use for the weights storage maybe a complete removal should be considered in future major versions.